### PR TITLE
Feature: add and implement arguments and base methods

### DIFF
--- a/bin/wc_dart.dart
+++ b/bin/wc_dart.dart
@@ -10,19 +10,24 @@ void main(List<String> arguments) async {
   parser.addFlag('lines', abbr: 'l');
   parser.addFlag('words', abbr: 'w');
   parser.addFlag('chars', abbr: 'm');
+  parser.addFlag('version', abbr: 'v');
 
   ArgResults argResults = parser.parse(arguments);
 
   final List<String> paths = argResults.rest;
   final bool allCommands = !argResults.wasParsed('bytes') && !argResults.wasParsed('lines') && !argResults.wasParsed('chars') && !argResults.wasParsed('words');
 
-  await wc(
-    paths,
-    countBytes: allCommands ? true : argResults.wasParsed('bytes'),
-    countLines: allCommands ? true : argResults.wasParsed('lines'),
-    countChars: allCommands ? true : argResults.wasParsed('chars'),
-    countWords: allCommands ? true : argResults.wasParsed('words'),
-  );
+  if (argResults.wasParsed('version')) {
+    stdout.writeln(await wc_dart.getVersion());
+  } else {
+    await wc(
+      paths,
+      countBytes: allCommands ? true : argResults.wasParsed('bytes'),
+      countLines: allCommands ? true : argResults.wasParsed('lines'),
+      countChars: allCommands ? true : argResults.wasParsed('chars'),
+      countWords: allCommands ? true : argResults.wasParsed('words'),
+    );
+  }
 }
 
 Future<void> wc(

--- a/bin/wc_dart.dart
+++ b/bin/wc_dart.dart
@@ -35,30 +35,34 @@ Future<void> wc(
   if (paths.isEmpty) {
     stderr.writeln('Error: no file found.');
   } else {
-    for (int index = 0; index < paths.length; index++) {
-      final File file = File(paths[index]);
+    try {
+      for (int index = 0; index < paths.length; index++) {
+        final File file = File(paths[index]);
 
-      if (countBytes) {
-        final int bytes = await wc_dart.countBytes(file);
-        stdout.write(wc_dart.padRight(bytes.toString()));
+        if (countBytes) {
+          final int bytes = await wc_dart.countBytes(file);
+          stdout.write(wc_dart.padRight(bytes.toString()));
+        }
+
+        if (countLines) {
+          final int lines = await wc_dart.countLines(file);
+          stdout.write(wc_dart.padRight(lines.toString()));
+        }
+
+        if (countWords) {
+          final int words = await wc_dart.countWords(file);
+          stdout.write(wc_dart.padRight(words.toString()));
+        }
+
+        if (countChars) {
+          final int chars = await wc_dart.countChars(file);
+          stdout.write(wc_dart.padRight(chars.toString()));
+        }
+
+        stdout.writeln(wc_dart.padRight(file.path));
       }
-
-      if (countLines) {
-        final int lines = await wc_dart.countLines(file);
-        stdout.write(wc_dart.padRight(lines.toString()));
-      }
-
-      if (countWords) {
-        final int words = await wc_dart.countWords(file);
-        stdout.write(wc_dart.padRight(words.toString()));
-      }
-
-      if (countChars) {
-        final int chars = await wc_dart.countChars(file);
-        stdout.write(wc_dart.padRight(chars.toString()));
-      }
-
-      stdout.write(wc_dart.padRight(file.path));
+    } catch (e) {
+      stderr.writeln('Error: $e');
     }
   }
 }

--- a/bin/wc_dart.dart
+++ b/bin/wc_dart.dart
@@ -1,5 +1,68 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
 import 'package:wc_dart/wc_dart.dart' as wc_dart;
 
-void main(List<String> arguments) {
-  print('Hello world: ${wc_dart.calculate()}!');
+void main(List<String> arguments) async {
+  final ArgParser parser = ArgParser();
+
+  parser.addFlag('bytes', abbr: 'c');
+  parser.addFlag('lines', abbr: 'l');
+  parser.addFlag('words', abbr: 'w');
+  parser.addFlag('chars', abbr: 'm');
+
+  ArgResults argResults = parser.parse(arguments);
+
+  final List<String> paths = argResults.rest;
+  final bool allCommands = !argResults.wasParsed('bytes') && !argResults.wasParsed('lines') && !argResults.wasParsed('chars') && !argResults.wasParsed('words');
+
+  await wc(
+    paths,
+    countBytes: allCommands ? true : argResults.wasParsed('bytes'),
+    countLines: allCommands ? true : argResults.wasParsed('lines'),
+    countChars: allCommands ? true : argResults.wasParsed('chars'),
+    countWords: allCommands ? true : argResults.wasParsed('words'),
+  );
+}
+
+String padRight(String value) {
+  return '$value ';
+}
+
+Future<void> wc(
+  List<String> paths, {
+  bool countBytes = false,
+  bool countLines = false,
+  bool countWords = false,
+  bool countChars = false,
+}) async {
+  if (paths.isEmpty) {
+    stderr.writeln('Error: no file found.');
+  } else {
+    for (int index = 0; index < paths.length; index++) {
+      final File file = File(paths[index]);
+
+      if (countBytes) {
+        final int bytes = await wc_dart.countBytes(file);
+        stdout.write(padRight(bytes.toString()));
+      }
+
+      if (countLines) {
+        final int lines = await wc_dart.countLines(file);
+        stdout.write(padRight(lines.toString()));
+      }
+
+      if (countWords) {
+        final int words = await wc_dart.countWords(file);
+        stdout.write(padRight(words.toString()));
+      }
+
+      if (countChars) {
+        final int chars = await wc_dart.countChars(file);
+        stdout.write(padRight(chars.toString()));
+      }
+
+      stdout.write(padRight(file.path));
+    }
+  }
 }

--- a/bin/wc_dart.dart
+++ b/bin/wc_dart.dart
@@ -11,15 +11,19 @@ void main(List<String> arguments) async {
   parser.addFlag('words', abbr: 'w');
   parser.addFlag('chars', abbr: 'm');
   parser.addFlag('version', abbr: 'v');
+  parser.addFlag('help', abbr: 'h');
 
   ArgResults argResults = parser.parse(arguments);
 
-  final List<String> paths = argResults.rest;
-  final bool allCommands = !argResults.wasParsed('bytes') && !argResults.wasParsed('lines') && !argResults.wasParsed('chars') && !argResults.wasParsed('words');
-
   if (argResults.wasParsed('version')) {
     stdout.writeln(await wc_dart.getVersion());
+  } else if (argResults.wasParsed('help')) {
+    stdout.write(wc_dart.getHelp());
   } else {
+    final List<String> paths = argResults.rest;
+    final bool allCommands =
+        !argResults.wasParsed('bytes') && !argResults.wasParsed('lines') && !argResults.wasParsed('chars') && !argResults.wasParsed('words');
+
     await wc(
       paths,
       countBytes: allCommands ? true : argResults.wasParsed('bytes'),

--- a/bin/wc_dart.dart
+++ b/bin/wc_dart.dart
@@ -25,10 +25,6 @@ void main(List<String> arguments) async {
   );
 }
 
-String padRight(String value) {
-  return '$value ';
-}
-
 Future<void> wc(
   List<String> paths, {
   bool countBytes = false,
@@ -44,25 +40,25 @@ Future<void> wc(
 
       if (countBytes) {
         final int bytes = await wc_dart.countBytes(file);
-        stdout.write(padRight(bytes.toString()));
+        stdout.write(wc_dart.padRight(bytes.toString()));
       }
 
       if (countLines) {
         final int lines = await wc_dart.countLines(file);
-        stdout.write(padRight(lines.toString()));
+        stdout.write(wc_dart.padRight(lines.toString()));
       }
 
       if (countWords) {
         final int words = await wc_dart.countWords(file);
-        stdout.write(padRight(words.toString()));
+        stdout.write(wc_dart.padRight(words.toString()));
       }
 
       if (countChars) {
         final int chars = await wc_dart.countChars(file);
-        stdout.write(padRight(chars.toString()));
+        stdout.write(wc_dart.padRight(chars.toString()));
       }
 
-      stdout.write(padRight(file.path));
+      stdout.write(wc_dart.padRight(file.path));
     }
   }
 }

--- a/bin/wc_dart.dart
+++ b/bin/wc_dart.dart
@@ -48,11 +48,6 @@ Future<void> wc(
       for (int index = 0; index < paths.length; index++) {
         final File file = File(paths[index]);
 
-        if (countBytes) {
-          final int bytes = await wc_dart.countBytes(file);
-          stdout.write(wc_dart.padRight(bytes.toString()));
-        }
-
         if (countLines) {
           final int lines = await wc_dart.countLines(file);
           stdout.write(wc_dart.padRight(lines.toString()));
@@ -66,6 +61,11 @@ Future<void> wc(
         if (countChars) {
           final int chars = await wc_dart.countChars(file);
           stdout.write(wc_dart.padRight(chars.toString()));
+        }
+
+        if (countBytes) {
+          final int bytes = await wc_dart.countBytes(file);
+          stdout.write(wc_dart.padRight(bytes.toString()));
         }
 
         stdout.writeln(wc_dart.padRight(file.path));

--- a/lib/wc_dart.dart
+++ b/lib/wc_dart.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:typed_data';
+import 'package:path/path.dart' show dirname, join;
 
 Future<int> countBytes(File file) async {
   final Uint8List bytes = await file.readAsBytes();
@@ -23,4 +24,18 @@ Future<int> countWords(File file) async {
 
 String padRight(String value) {
   return '$value ';
+}
+
+Future<String> getVersion() async {
+  String version = '';
+  List<String> dirList = dirname(Platform.script.path).split('/');
+  dirList.removeAt(0);
+  dirList.removeLast();
+
+  String fixedDir = dirList.join('/').replaceAllMapped(RegExp(r'%20'), (_) => ' ');
+
+  final File pubFile = File('$fixedDir/pubspec.yaml');
+  final String text = await pubFile.readAsString();
+
+  return RegExp(r'version:.+').firstMatch(text)?.group(0) ?? version;
 }

--- a/lib/wc_dart.dart
+++ b/lib/wc_dart.dart
@@ -20,3 +20,7 @@ Future<int> countWords(File file) async {
   final String text = await file.readAsString();
   return RegExp(r'[\w-]+').allMatches(text).length;
 }
+
+String padRight(String value) {
+  return '$value ';
+}

--- a/lib/wc_dart.dart
+++ b/lib/wc_dart.dart
@@ -1,3 +1,22 @@
-int calculate() {
-  return 6 * 7;
+import 'dart:io';
+import 'dart:typed_data';
+
+Future<int> countBytes(File file) async {
+  final Uint8List bytes = await file.readAsBytes();
+  return bytes.length;
+}
+
+Future<int> countLines(File file) async {
+  final List<String> lines = await file.readAsLines();
+  return lines.length;
+}
+
+Future<int> countChars(File file) async {
+  final String text = await file.readAsString();
+  return text.length;
+}
+
+Future<int> countWords(File file) async {
+  final String text = await file.readAsString();
+  return RegExp(r'[\w-]+').allMatches(text).length;
 }

--- a/lib/wc_dart.dart
+++ b/lib/wc_dart.dart
@@ -39,3 +39,16 @@ Future<String> getVersion() async {
 
   return RegExp(r'version:.+').firstMatch(text)?.group(0) ?? version;
 }
+
+String getHelp() {
+  return '''
+Usage: wc_dart [OPTION]... [FILE]...
+
+Print newline, word, and byte counts for each FILE, and a total line if more than one FILE is specified. A word is a non-zero-length sequence of characteres delimited by white space.
+
+The options below may be used to select which counts are printed, always in the following order: newline, word, character, byte.
+    -c, --bytes ${' ' * 5} print the byte counts
+    -m, --chars ${' ' * 5} print the character counts
+    -l, --lines ${' ' * 5} print the newline counts
+    -w, --words ${' ' * 5} print the word counts''';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 # Add regular dependencies here.
 dependencies:
+  args: ^2.4.1
   # path: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
Add and implement arguments and base methods.

`wc_dart` currently supports these commands:
| Command | Flag | Description |
| ---------- | ----- | ----------- |
| bytes | c | Count bytes from a file |
| lines | l | Count lines from a file |
| words | w | Count words from a file |
| chars | m | Count characters from a file |
| help | h | Print wc_dart options and exit |
| version | v | Print wc_dart version |

Example:
```
> dart run bin/wc_dart.dart test.txt
7137 59343 339119 341836 test.txt 
```

`wc_dart` also supports multiple files.
Example:
```
> dart run bin/wc_dart.dart test.txt LICENSE CHANGELOG.md
7137 59343 339119 341836 test.txt 
21 170 1091 1091 LICENSE 
3 6 29 29 CHANGELOG.md
```